### PR TITLE
Avoid Multiple AutoHide Animations

### DIFF
--- a/lib/symbols-tree-view.coffee
+++ b/lib/symbols-tree-view.coffee
@@ -54,7 +54,7 @@ module.exports =
           @off('mouseenter mouseleave')
         else
           @width(minimalWidth)
-          @stop(true, true)
+          @stop()
 
           @mouseenter (event) =>
             @animate({width: originalWidth}, duration: @animationDuration)

--- a/lib/symbols-tree-view.coffee
+++ b/lib/symbols-tree-view.coffee
@@ -54,6 +54,7 @@ module.exports =
           @off('mouseenter mouseleave')
         else
           @width(minimalWidth)
+          @stop(true, true)
 
           @mouseenter (event) =>
             @animate({width: originalWidth}, duration: @animationDuration)


### PR DESCRIPTION
I'm not sure if this works, never worked with coffe script, but always when you work with animate, you should use .stop(true, true) before, so it doesn't queue a lot of animations and it gets weird.