### PR TITLE
Avoid Multiple AutoHide Animations

### DIFF
--- a/lib/symbols-tree-view.coffee
+++ b/lib/symbols-tree-view.coffee
@@ -128,9 +128,11 @@ module.exports =
           @off('mouseenter mouseleave')
         else
           @mouseenter (event) =>
+            @stop()
             @animate({width: @originalWidth}, duration: @animationDuration)
 
           @mouseleave (event) =>
+            @stop()
             if atom.config.get('tree-view.showOnRightSide')
               @animate({width: @minimalWidth}, duration: @animationDuration) if event.offsetX > 0
             else


### PR DESCRIPTION
I'm not sure if this works, never worked with coffe script, but always when you work with animate, you should use .stop() before, so it doesn't queue a lot of animations and it gets weird.

Continuation of https://github.com/xndcn/symbols-tree-view/pull/25