### PR TITLE
Add commands to show/hide treeview pane.

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -20,6 +20,8 @@ module.exports =
   activate: (state) ->
     @symbolsTreeView = new SymbolsTreeView(state.symbolsTreeViewState)
     atom.commands.add 'atom-workspace', 'symbols-tree-view:toggle': => @symbolsTreeView.toggle()
+    atom.commands.add 'atom-workspace', 'symbols-tree-view:show': => @symbolsTreeView.show()
+    atom.commands.add 'atom-workspace', 'symbols-tree-view:hide': => @symbolsTreeView.hide()
 
     atom.config.observe 'tree-view.showOnRightSide', (value) =>
       if @symbolsTreeView.hasParent()

--- a/lib/symbols-tree-view.coffee
+++ b/lib/symbols-tree-view.coffee
@@ -164,9 +164,7 @@ module.exports =
         if left + @contextMenu.width() > atom.getSize().width
           left = left - @contextMenu.width()
         @contextMenu.css({left: left, top: event.pageY})
-        @contextMenu.show()
-        return false #disable original atom context menu
-
+        @contextMenu.show()view reconfiguration
     removeEventForEditor: ->
       @onEditorSave?.dispose()
       @onChangeRow?.dispose()
@@ -188,3 +186,14 @@ module.exports =
       else
         @populate()
         @attach()
+
+    # Show this view if hidden
+    show: ->
+      if not @hasParent()
+        @populate()
+        @attach()
+
+    # Hide this view if visible
+    hide: ->
+      if @hasParent()
+        @remove()


### PR DESCRIPTION
Please consider this pull request. It simply adds commands to hide or show the treeview explicitly (rather than relying on one keybinding for toggle)

This allows me (and others) to add initscripts that don't depend on the pre-existing state of the symbols tree view.
