### PR TITLE
Add commands to show/hide treeview pane.

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -20,6 +20,8 @@ module.exports =
   activate: (state) ->
     @symbolsTreeView = new SymbolsTreeView(state.symbolsTreeViewState)
     atom.commands.add 'atom-workspace', 'symbols-tree-view:toggle': => @symbolsTreeView.toggle()
+    atom.commands.add 'atom-workspace', 'symbols-tree-view:show': => @symbolsTreeView.show()
+    atom.commands.add 'atom-workspace', 'symbols-tree-view:hide': => @symbolsTreeView.hide()
 
     atom.config.observe 'tree-view.showOnRightSide', (value) =>
       if @symbolsTreeView.hasParent()

--- a/lib/symbols-tree-view.coffee
+++ b/lib/symbols-tree-view.coffee
@@ -188,3 +188,14 @@ module.exports =
       else
         @populate()
         @attach()
+
+    # Show this view if hidden
+    show: ->
+      if not @hasParent()
+        @attach()
+
+    # Hide this view if visible
+    show: ->
+      if @hasParent()
+        @populate()
+        @remove()


### PR DESCRIPTION
Please consider this pull request. It simply adds commands to hide or show the treeview explicitly (rather than relying on one keybinding for toggle)

This allows me (and others) to add initscripts that don't depend on the pre-existing state of the symbols tree view.

(Sorry about the previous 2 botched pull requests...had typos, this one is for real.)
