### PR TITLE
Made sortByNameScopes work when files just opened.

### DIFF
--- a/lib/symbols-tree-view.coffee
+++ b/lib/symbols-tree-view.coffee
@@ -114,6 +114,7 @@ module.exports =
         @sortByNameScopes = atom.config.get('symbols-tree-view.sortByNameScopes')
         if @sortByNameScopes.indexOf(@getScopeName()) != -1
           @cachedStatus[editor].nowSortStatus[0] = true
+          @treeView.sortByName()
         {@nowTypeStatus, @nowSortStatus} = @cachedStatus[editor]
 
       @contextMenu.addMenu(type, @nowTypeStatus[type], toggleTypeVisible) for type in types


### PR DESCRIPTION
sortByNameScopes has not been worked when files just opened.
Fixed the issue.