### PR TITLE
Add missing hyperclick provider name

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -54,10 +54,9 @@ module.exports =
 
   getProvider: ->
     view = @symbolsTreeView
-    { getSuggestionForWord: (textEditor, text, range) =>
-      {
-        range: range
-        callback: ()=>
-          view.focusClickedTag.bind(view)(textEditor, text)
-      }
-    }
+
+    providerName: 'symbols-tree-view'
+    getSuggestionForWord: (textEditor, text, range) =>
+      range: range
+      callback: ()=>
+        view.focusClickedTag.bind(view)(textEditor, text)


### PR DESCRIPTION
Recent versions of the hyperclick package require that providers include a `providerName` property, which means that users with both packages installed encounter the following error after launch:
> Missing "providerName" property for hyperclick provider.

This change fixes that error by adding a `providerName` to the exported provider.