### PR TITLE
Matlab-like language .ctags

### DIFF
--- a/lib/.ctags
+++ b/lib/.ctags
@@ -172,3 +172,11 @@
 --regex-sql=/^[ \t]*create[ \t]+([a-zA-Z0-9\t]*)?(publication|subscription to|synchronization user)[\t]+([^.]+\.)?"?([a-zA-Z0-9_@.]+)/\4/m,mobilink/i
 --regex-sql=/^[ \t]*create[ \t]+([a-zA-Z0-9 \t]*)?(variable)[\t]+([^.]+\.)?"?([a-zA-Z0-9_@.]+)/\4/v,variable/i
 --regex-sql=/^[ \t]*create[ \t]+([a-zA-Z0-9\t]*)?(rule|schema|server|datatype|database|message)[\t]+([^.]+\.)?"?([a-zA-Z0-9_@.]+)/\4/o,other/I
+
+--langdef=Scilab
+--langmap=Scilab:.sce
+--langmap=Scilab:+.sci
+--langmap=Scilab:+.m
+--langmap=Scilab:+.kla
+--regex-Scilab=#(^///[ \t]*\$begin[ \t])+ScriptHeader#Script-Header#s,package#i
+--regex-Scilab=#^[ \t]*function.*[ \t]]*([a-zA-Z_][a-zA-Z0-9_]*)\(#\1#q,function#

--- a/lib/tag-generator.coffee
+++ b/lib/tag-generator.coffee
@@ -51,6 +51,9 @@ module.exports =
         'text.html'             : 'Html'
         'text.html.php'         : 'Php'
         'source.livecodescript' : 'LiveCode'
+        'source.scilab'         : 'Scilab' # Scilab
+        'source.matlab'         : 'Scilab' # Matlab
+        'source.octave'         : 'Scilab' # GNU Octave
 
         # For backward-compatibility with Atom versions < 0.166
         'source.c++'            : 'C++'


### PR DESCRIPTION
Adds support for Matlab / Octave / Scilab.
Also defines a regex for a Scilab dialect which does not affect the generation of the other files.
