### PR TITLE
Fix issue #15

### DIFF
--- a/lib/symbols-tree-view.coffee
+++ b/lib/symbols-tree-view.coffee
@@ -72,7 +72,7 @@ module.exports =
             @focusCurrentCursorTag()
 
     focusCurrentCursorTag: ->
-      if editor = @getEditor()
+      if (editor = @getEditor()) and @parser?
         row = editor.getCursorBufferPosition().row
         tag = @parser.getNearestTag(row)
         @treeView.select(tag)


### PR DESCRIPTION
Uncaught TypeError: Cannot read property 'getNearestTag' of undefined

This was caused by a race condition:
editor.onDidChangeCursorPosition fired before the parser had successfully parsed.

This fix will check @parser existence before trying to focus on the cursor tag.