### PR TITLE
Added showOnRightSide functionality

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -41,17 +41,17 @@ module.exports =
     atom.commands.add 'atom-workspace', 'symbols-tree-view:show': => @symbolsTreeView.showView()
     atom.commands.add 'atom-workspace', 'symbols-tree-view:hide': => @symbolsTreeView.hideView()
 
-    atom.config.observe 'tree-view.showOnRightSide', (value) =>
-      if @symbolsTreeView.hasParent()
-        @symbolsTreeView.remove()
-        @symbolsTreeView.populate()
-        @symbolsTreeView.attach()
-
     atom.config.observe "symbols-tree-view.autoToggle", (enabled) =>
       if enabled
         @symbolsTreeView.toggle() unless @symbolsTreeView.hasParent()
       else
         @symbolsTreeView.toggle() if @symbolsTreeView.hasParent()
+
+    atom.config.observe 'tree-view.showOnRightSide', (value) =>
+      @symbolsTreeView.updatePane()
+
+    atom.config.observe 'symbols-tree-view.showOnRightSide', (value) =>
+      @symbolsTreeView.updatePane()
 
   deactivate: ->
     @symbolsTreeView.destroy()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -6,6 +6,10 @@ module.exports =
       type: 'boolean'
       default: false
       description: 'If this option is enabled then symbols-tree-view will auto open when you open files.'
+    showOnRightSide:
+      type: 'boolean'
+      default: false
+      description: 'If this option is enabled then symbols-tree-view will show up on the right hand side. Otherwise, the default tree-view setting is used.'
     scrollAnimation:
       type: 'boolean'
       default: true

--- a/lib/symbols-tree-view.coffee
+++ b/lib/symbols-tree-view.coffee
@@ -121,6 +121,12 @@ module.exports =
       @contextMenu.addSeparator()
       @contextMenu.addMenu('sort by name', @nowSortStatus[0], toggleSortByName)
 
+    updatePane : ->
+      if @hasParent()
+        @remove()
+        @populate()
+        @attach()
+
     generateTags: (filePath) ->
       new TagGenerator(filePath, @getScopeName()).generate().done (tags) =>
         @parser = new TagParser(tags, @getScopeName())


### PR DESCRIPTION
Hi.
I believe it to be effective from the UX pov to to keep all panes to the right, because my eyes look for code more naturally on the left hand side of the screen, coinciding with the editor's leftmost border. 

Therefore, I am proposing to you a simple functionality that forces Symbols Tree View to the right hand side of the editor. It is designed to take into account the current default behaviour of your package (which shows Symbols Tree View opposite to Tree View, Atom's default package), overriding it.

Hope you deem this useful as well.

Best,
Niccolò