### PR TITLE
Fix issue #148 regarding path.extname

### DIFF
--- a/lib/tag-generator.coffee
+++ b/lib/tag-generator.coffee
@@ -24,7 +24,7 @@ module.exports =
         return null
 
     getLanguage: ->
-      return 'Cson' if path.extname(@path) in ['.cson', '.gyp']
+      return 'Cson' if (@path && path.extname(@path) in ['.cson', '.gyp'])
 
       {
         'source.c'              : 'C'


### PR DESCRIPTION
As I understand it, @path can be undefined, as it is obtained by doing filePath = editor.getPath()