### PR TITLE
BUGFIX issue #79

### DIFF
--- a/lib/symbols-tree-view.coffee
+++ b/lib/symbols-tree-view.coffee
@@ -79,7 +79,7 @@ module.exports =
 
     focusClickedTag: (editor, text) ->
       console.log "clicked: #{text}"
-      if editor = @getEditor()
+      if @parser && editor = @getEditor()
         tag =  (t for t in @parser.tags when t.name is text)[0]
         @treeView.select(tag)
         # imho, its a bad idea =(


### PR DESCRIPTION
BUGFIX for #79: Uncaught TypeError: Cannot read property 'tags' of undefined

does not fix any underlying problem (e.g. why is `focusClickedTag()` called at all), but prevents the error