### PR TITLE
Added text.md enabling for Markdown parsing

### DIFF
--- a/lib/tag-generator.coffee
+++ b/lib/tag-generator.coffee
@@ -35,6 +35,7 @@ module.exports =
         'source.css.less'       : 'Css'
         'source.css.scss'       : 'Css'
         'source.gfm'            : 'Markdown'
+        'text.md'               : 'Markdown'
         'source.go'             : 'Go'
         'source.java'           : 'Java'
         'source.js'             : 'JavaScript'


### PR DESCRIPTION
Many markdown packages replace source.gfm with text.md.
The added line adds support for the latter.