### PR TITLE
Added support for foldable, atx-style markdown headings (#); plus listing of images, and tables

### DIFF
--- a/lib/.ctags
+++ b/lib/.ctags
@@ -35,7 +35,14 @@
 --langmap=Markdown:+.mkd
 --langmap=Markdown:+.mkdown
 --langmap=Markdown:+.ron
---regex-Markdown=/^#+[ \t]*([^#]+)/\1/f,function/
+--regex-Markdown=/^#{1}[ \t]*([^#]+)/\1/a,header-1/
+--regex-Markdown=/^#{2}[ \t]*([^#]+)/\1/b,header-2/
+--regex-Markdown=/^#{3}[ \t]*([^#]+)/\1/c,header-3/
+--regex-Markdown=/^#{4}[ \t]*([^#]+)/\1/d,header-4/
+--regex-Markdown=/^#{5}[ \t]*([^#]+)/\1/e,header-5/
+--regex-Markdown=/^#{6}[ \t]*([^#]+)/\1/f,header-6/
+--regex-Markdown=/!\[(.*)\]\(.*\)/\1/x,image/
+--regex-Markdown=/^[ \t]*Table: (.*)/\1/y,table/
 
 --langdef=Json
 --langmap=Json:.json

--- a/lib/tag-parser.coffee
+++ b/lib/tag-parser.coffee
@@ -99,6 +99,8 @@ module.exports =
           key = tag.type + ':' + parent + @splitSymbol + tag.name
         else
           key = tag.type + ':' + tag.name
+          # add row number to avoid issues in markdown documents with repeating heading names
+          key = tag.type + ':' + tag.position.row + ':' + tag.name if @grammar == 'source.gfm' or @grammar == 'text.md'
           tag.parentKey = key # store for consistency
         parents[key] = tag
 

--- a/lib/tag-parser.coffee
+++ b/lib/tag-parser.coffee
@@ -121,6 +121,7 @@ module.exports =
       for tag in @tags
         tag.label = tag.name
         tag.icon = "icon-#{tag.type}"
+        tag.icon += " icon-hierarchy-break" if tag.hierarchy_break
         if tag.parent
           parent = parents[tag.parent]
           parent.children ?= []

--- a/lib/tag-parser.coffee
+++ b/lib/tag-parser.coffee
@@ -129,7 +129,10 @@ module.exports =
           roots.push(tag)
         types[tag.type] = null
 
-      return {root: {label: 'root', icon: null, children: roots}, types: Object.keys(types)}
+      types = Object.keys(types)
+      types = types.sort() if @grammar == 'source.gfm' or @grammar == 'text.md'
+
+      return {root: {label: 'root', icon: null, children: roots}, types: types}
 
     getNearestTag: (row) ->
       left = 0

--- a/styles/symbols-tree-view.less
+++ b/styles/symbols-tree-view.less
@@ -62,6 +62,51 @@
   content: @@name;
 }
 
+.symbols-tree-view .icon-header-1::before {
+  content: '⚫';
+  font-size: 140%;
+}
+.symbols-tree-view .icon-header-1 {
+  font-weight: bold;
+  font-size: 120%;
+}
+
+.symbols-tree-view .icon-header-2::before {
+  content: '⚫';
+  font-size: 120%;
+}
+.symbols-tree-view .icon-header-2 {
+  font-size: 120%;
+}
+
+.symbols-tree-view .icon-header-3::before {
+  content: '♦';
+  font-size: 120%;
+}
+
+.symbols-tree-view .icon-header-4::before {
+  content: '④';
+  font-size: 120%;
+}
+
+.symbols-tree-view .icon-header-5::before {
+  content: '⑤';
+  font-size: 120%;
+}
+
+.symbols-tree-view .icon-header-6::before {
+  content: '⑥';
+  font-size: 120%;
+}
+
+.symbols-tree-view .icon-image::before {
+  content: '★';
+}
+
+.symbols-tree-view .icon-table::before {
+  content: '☷';
+}
+
 .symbols-tree-view .icon-function::before {
   .symbol-icon(symbol-function);
 }

--- a/styles/symbols-tree-view.less
+++ b/styles/symbols-tree-view.less
@@ -62,6 +62,11 @@
   content: @@name;
 }
 
+.symbols-tree-view .icon-hierarchy-break::after {
+  content: " ⚠";
+  font-size: 120%;
+}
+
 .symbols-tree-view .icon-header-1::before {
   content: '⚫';
   font-size: 140%;


### PR DESCRIPTION
A hierarchy of Markdown headings is created and foldable.
The extensions also search for tables (pandoc style) and images in the file.

This solves issues #173 , #135 , #127 .